### PR TITLE
Add bias and weight distribution modeling

### DIFF
--- a/docs/simulation/arbiter_puf.rst
+++ b/docs/simulation/arbiter_puf.rst
@@ -46,6 +46,16 @@ array([-1, -1,  1], dtype=int8)
 array([-1, -1, -1], dtype=int8)
 
 In above example, note that the response to the `same` third challenge evaluates to a different response due to noise.
+
+Modeling Non-Ideal Bias and Weights
+-----------------------------------
+
+Real-world implementations often exhibit systematic bias and variations across
+the delay stages.  The constructors of :class:`~pypuf.simulation.ArbiterPUF` and
+its derivatives therefore accept additional parameters ``bias_mean``,
+``bias_stddev``, ``weight_mean`` and ``weight_stddev`` to control the
+distribution of the intrinsic delays.  A linear ``gradient`` can be specified to
+model manufacturing effects along the chain.
 This is reproducible with new instantiations using the same seed.
 
 XOR Arbiter PUF

--- a/pypuf/simulation/base.py
+++ b/pypuf/simulation/base.py
@@ -6,7 +6,7 @@ from typing import Union, Callable
 
 from numpy import prod, sign, sqrt, append, empty, ceil, \
     ones, zeros, reshape, einsum, int8, \
-    concatenate, ndarray, transpose, broadcast_to, array
+    concatenate, ndarray, transpose, broadcast_to, array, linspace
 from numpy.random import default_rng
 
 
@@ -281,14 +281,28 @@ class LTFArray(Simulation):
             sub_challenges[:, :, i] *= sub_challenges[:, :, i + 1]
 
     @classmethod
-    def normal_weights(cls, n: int, k: int, seed: int, mu: float = 0, sigma: float = 1) -> ndarray:
+    def normal_weights(
+        cls,
+        n: int,
+        k: int,
+        seed: int,
+        mu: float = 0,
+        sigma: float = 1,
+        gradient: float = 0.0,
+    ) -> ndarray:
+        """Return normally distributed weights.
+
+        The weights are drawn from a normal distribution with mean ``mu`` and
+        standard deviation ``sigma``.  If ``gradient`` is given, the mean of the
+        distribution is shifted linearly along the challenge bits to emulate a
+        manufacturing gradient often observed on real hardware.
         """
-        Returns weights for an array of k LTFs of size n each.
-        The weights are drawn from a normal distribution with given
-        mean and std. deviation, if parameters are omitted, the
-        standard normal distribution is used.
-        """
-        return default_rng(seed).normal(loc=mu, scale=sigma, size=(k, n))
+        rng = default_rng(seed)
+        weights = rng.normal(loc=mu, scale=sigma, size=(k, n))
+        if gradient:
+            offsets = linspace(-0.5, 0.5, n) * gradient
+            weights += offsets
+        return weights
 
     def __init__(self, weight_array: ndarray, transform: Union[str, Callable], combiner: Union[str, Callable] = 'xor',
                  bias: ndarray = None) -> None:

--- a/test/simulation/test_delay.py
+++ b/test/simulation/test_delay.py
@@ -169,3 +169,20 @@ def test_ff_many_loops() -> None:
     assert set(np.unique(puf.eval(pypuf.io.random_inputs(n=puf.challenge_length, N=100, seed=1)))) == {-1, 1}
     assert -.5 < pypuf.metrics.bias(puf, seed=1) < .5
     assert pypuf.metrics.bias(puf, seed=1) != 0
+
+
+def test_bias_parameter_effect() -> None:
+    puf = pypuf.simulation.ArbiterPUF(n=8, seed=1, bias_mu=2.0, bias_sigma=0)
+    assert puf.weight_array[0, -1] == 2.0
+
+
+def test_weight_gradient() -> None:
+    puf = pypuf.simulation.ArbiterPUF(
+        n=4,
+        seed=1,
+        weight_mu=0,
+        weight_sigma=0,
+        gradient=1.0,
+    )
+    expected = np.linspace(-0.5, 0.5, 4)
+    assert np.allclose(puf.weight_array[0, :-1], expected)


### PR DESCRIPTION
Summary
- allow custom weight and bias distributions for Arbiter PUFs
- support linear gradients in weight generation
- document the new parameters
- adding regression tests